### PR TITLE
fixed linting warning, typo, and wrong name in package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ tests in this lab.
 
 If you've got it working and have the app served up on a browser tab, you'll see
 that, upon refresh, a timer will be present. The timer is still not working, but
-that's okay for now.e
+that's okay for now.
 
 #### Timer
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-component-updating-lab",
+  "name": "react-component-mounting-lab",
   "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,
@@ -4572,7 +4572,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4590,11 +4591,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4607,15 +4610,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4718,7 +4724,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4728,6 +4735,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4740,17 +4748,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -4767,6 +4778,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4839,7 +4851,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4849,6 +4862,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4924,7 +4938,8 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4954,6 +4969,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4971,6 +4987,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5009,11 +5026,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-component-updating-lab",
+  "name": "react-component-mounting-lab",
   "version": "0.1.0",
   "private": true,
   "babel": {

--- a/src/Timer.js
+++ b/src/Timer.js
@@ -1,31 +1,21 @@
-import React, { Component } from 'react';
+import React, { Component } from "react";
 
 class Timer extends Component {
-
   state = {
     time: 0,
-    color: '#'+Math.floor(Math.random()*16777215).toString(16)
-  }
+    color: "#" + Math.floor(Math.random() * 16777215).toString(16)
+  };
 
   // add your code here
 
-
-
-
-
-
-
   render() {
-
-    const { time, color, className } = this.state
+    const { time, color } = this.state;
     return (
-      <section className="Timer" style={{background: color}}>
-
-        <h1>{ time }</h1>
-        <button onClick={ this.stopClock }>Stop</button>
+      <section className="Timer" style={{ background: color }}>
+        <h1>{time}</h1>
+        <button onClick={this.stopClock}>Stop</button>
         <aside className="mountText">Mounted</aside>
-        <small onClick={ this.handleClose }>X</small>
-
+        <small onClick={this.handleClose}>X</small>
       </section>
     );
   }
@@ -33,20 +23,18 @@ class Timer extends Component {
   //clock functions
   clockTick = () => {
     this.setState(prevState => ({
-      time: prevState.time+1
-    }))
-  }
+      time: prevState.time + 1
+    }));
+  };
 
   stopClock = () => {
-    clearInterval(this.interval)
-  }
+    clearInterval(this.interval);
+  };
 
   // for the 'x' button,
   handleClose = () => {
-    this.props.removeTimer(this.props.id)
-  }
-
-
+    this.props.removeTimer(this.props.id);
+  };
 }
 
 export default Timer;


### PR DESCRIPTION
Removed the linting error of unused className variable in Timer.js. Removed typo "e" in the README.md. And fixed the wrong name in package.json